### PR TITLE
fix: doc links and spelling

### DIFF
--- a/docs/docs-main/concepts/index.md
+++ b/docs/docs-main/concepts/index.md
@@ -35,7 +35,7 @@ With Magnetar, the idea is that your data is organized and accessible through mo
 
 Modules are dynamically created and destroyed when you read/write data! JavaScript will automatically garbage-collect modules that are not referenced anymore.
 
-The concept of modules in Magnetar was inspired by [Google Firestore and the Firebase SDK](https://firebase.google.com/docs/firestore/data-model). If you are already familiar with this SDK, feel free to skip this section and go straight to [Setup](#setup)
+The concept of modules in Magnetar was inspired by [Google Firestore and the Firebase SDK](https://firebase.google.com/docs/firestore/data-model). If you are already familiar with this SDK, feel free to skip this section and go straight to [Setup](../setup/)
 
 ### Collection vs Document Modules
 

--- a/docs/docs-main/module-setup/index.md
+++ b/docs/docs-main/module-setup/index.md
@@ -1,6 +1,6 @@
 # Module Setup
 
-Before you dive in here, it's best to have a basic grasp of how to [Add & Edit Data](#) and how to [Read Data](#). So check out that documentation first, and then come back here!
+Before you dive in here, it's best to have a basic grasp of how to [Add & Edit Data](../write-data/) and how to [Read Data](../read-data/). So check out that documentation first, and then come back here!
 
 ## Documenting your Data Structure
 
@@ -55,7 +55,7 @@ It's also become clear that these modules might be better off each having their 
 - `modifyPayloadOn.insert` — is triggered every time you write data locally (which is then synced to the server with those default values)
 - `modifyReadResponseOn.added` — is triggered every time data comes in from your remote store (the server)
 
-To learn more about these functions and other possibilities read [Hooks and Events](#hooks-and-events).
+To learn more about these functions and other possibilities read [Hooks and Events](../hooks-and-events/).
 
 ## Filtering Data with Queries
 
@@ -66,7 +66,7 @@ When you need to have only a sub-set of your documents in a collection, you have
 
 ### Set up a Query at the Module Level
 
-At the module level the query will be active whenever you try to read data with [fetch](#) or [stream](#). You should only set up the query at the module when you never need to query for other data in the same collection throughout your app.
+At the module level the query will be active whenever you try to read data with [fetch](../read-data/#fetch-data-once) or [stream](../read-data/#stream-realtime-updates). You should only set up the query at the module when you never need to query for other data in the same collection throughout your app.
 
 Example use case 1: **Filter and order documents based on some fields**
 
@@ -169,7 +169,7 @@ async function searchPokemon(type) {
 
 As you can see in the example, using a query in Magnetar is very powerful because it will not only query your read requests to the remote store, but can also apply that same query when reading your local data.
 
-You can find more information on reading data at [Read Data](#).
+You can find more information on reading data at [Read Data](../read-data/#query-data-filter-order-by-limit).
 
 ## Dynamic Module Paths
 

--- a/docs/docs-main/read-data/index.md
+++ b/docs/docs-main/read-data/index.md
@@ -9,7 +9,7 @@ There are two ways to retrieve data from your remote stores. Either of these met
 
 When you get data by executing `fetch()`, the data will be fetched from a server by your "remote" store plugin and then added to your module's data by your "local" store plugin.
 
-For displaying fetched data in the DOM see the [Displaying data in the DOM](#displaying-data-in-the-dom).
+For displaying fetched data in the DOM see the [Displaying data in the DOM](../setup/#displaying-data-in-the-dom).
 
 ### Fetch a Single Document
 
@@ -32,7 +32,7 @@ const data = bulbasaur.data
 The `fetch` action returns whatever data was fetched. When fetching a single document, the data will be an object.
 
 ```js
-// create the module and immidiately use the fetched data
+// create the module and immediately use the fetched data
 const bulbasaurData = await magnetar.doc('pokedex/001').fetch()
 
 // bulbasaurData ≈ { name: 'Bulbasaur' }
@@ -73,7 +73,7 @@ const allPokemon = pokedexModule.data.values()
 The `fetch` action returns whatever data was fetched. When fetching a collection, the data will be a Map <small>[？](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)</small>.
 
 ```js
-// create the module and immidiately use the fetched data
+// create the module and immediately use the fetched data
 const pokedexData = await magnetar.collection('pokedex').fetch()
 
 // pokedexData ≈ Map<
@@ -114,7 +114,7 @@ Afterwards, any changes to this document remotely will automatically be reflecte
 
 Please note: a streaming promise will never resolve as long as your stream is open! There is **no way** to know when or how many documents will be loaded in, as this depends on your remote store.
 
-For displaying streamed data in the DOM see the [Displaying data in the DOM](#displaying-data-in-the-dom).
+For displaying streamed data in the DOM see the [Displaying data in the DOM](../setup/#displaying-data-in-the-dom).
 
 ### Firestore vs Magnetar
 
@@ -123,7 +123,7 @@ The Firestore JS SDK has a [built-in feature for realtime updates](https://fireb
 - The syntax you have to use is very convoluted and complex
 - If your not careful, you can open the same stream twice and they both will use memory
 - You need to write a lot of code to capture the documents that comes in and save them in local cache
-- You need to organise where and how to temporarily save the function you get back to stop the stream
+- You need to organize where and how to temporarily save the function you get back to stop the stream
 
 Magnetar's Firestore Plugin uses `onSnapshot` [under the hood](https://github.com/CyCraft/magnetar/blob/production/packages/plugin-firestore/src/actions/stream.ts) but does these things for you:
 
@@ -214,7 +214,7 @@ magnetar
     // the stream was closed because of an error! !
   })
 
-// The code here will get executed immidiately
+// The code here will get executed immediately
 console.log('The stream was opened!')
 ```
 

--- a/docs/docs-main/setup/index.md
+++ b/docs/docs-main/setup/index.md
@@ -65,7 +65,7 @@ Some info on the main Magnetar instance props:
 - `stores` ⸺ an object with the store name as key and the store plugin instance as value
 - `localStoreName` ⸺ the name of the store that saves data locally
 - `executionOrder` ⸺ the execution order of your stores, this order is required for optimistic UI (but can be flipped)
-- `on` ⸺ event listeners for anything that happens in Magnetar, see the [Events chapter](#events) for more info
+- `on` ⸺ event listeners for anything that happens in Magnetar, see the [Events chapter](../hooks-and-events/) for more info
 
 ## Working with Modules
 
@@ -84,7 +84,7 @@ magnetar.collection('pokedex').doc('001')
 magnetar.doc('pokedex/001')
 ```
 
-Ideally you want to create a separate file for the modules you intend to use (or one file per module). This way you can more easily add some documentation on how the data structure looks for your database documents. <small>(for more info on this read [Module Setup](#))</small>
+Ideally you want to create a separate file for the modules you intend to use (or one file per module). This way you can more easily add some documentation on how the data structure looks for your database documents. <small>(for more info on this read [Module Setup](../module-setup/))</small>
 
 ```javascript
 import { magnetar } from 'magnetarSetup.js'

--- a/docs/docs-main/write-data/index.md
+++ b/docs/docs-main/write-data/index.md
@@ -1,6 +1,6 @@
 # Write Data
 
-Be sure to first read the [Setup chapter](#) to have a basic understanding.
+Be sure to first read the [Setup chapter](../setup/) to have a basic understanding.
 
 ## Insert a Document
 
@@ -60,7 +60,7 @@ const newDocModule = await pokedexModule.insert({ name: 'squirtle' })
 
 // ✅ instead do NOT await
 pokedexModule.insert({ name: 'squirtle' })
-// you can immidiately access the inserted data (even if the remote store takes a while longer)
+// you can immediately access the inserted data (even if the remote store takes a while longer)
 pokedexModule.data.values()
 ```
 


### PR DESCRIPTION
Fixed doc links to correspond with [VitePress Internal Links](https://vitepress.vuejs.org/guide/markdown#internal-links)

As well as few minor spelling mistakes.

Fixes #93  