### PR TITLE
fix: add test for FieldValue.increment to plugin-firestore-admin

### DIFF
--- a/packages/plugin-firestore-admin/test/external/fieldValue.test.ts
+++ b/packages/plugin-firestore-admin/test/external/fieldValue.test.ts
@@ -1,0 +1,29 @@
+import { pokedex } from '@magnetarjs/test-utils'
+import { FieldValue } from 'firebase-admin/firestore'
+import { assert, expect, test } from 'vitest'
+import { createMagnetarInstance } from '../helpers/createMagnetarInstance.js'
+import { firestoreDeepEqual } from '../helpers/firestoreDeepEqual.js'
+
+{
+  const testName = 'fieldValue increment'
+  test(testName, async () => {
+    const { pokedexModule } = await createMagnetarInstance(testName, {
+      insertDocs: { 'pokedex/1': pokedex(1) },
+    })
+    await firestoreDeepEqual(testName, 'pokedex/1', pokedex(1))
+    assert.deepEqual(pokedexModule.doc('1').data, pokedex(1))
+
+    const payload = { base: { HP: FieldValue.increment(1) as any } }
+    try {
+      await pokedexModule.doc('1').merge(payload)
+    } catch (error) {
+      assert.fail(JSON.stringify(error))
+    }
+
+    const _pokedex = pokedexModule.doc('1').data
+    const pokedexHp = _pokedex?.base.HP as any
+
+    expect(pokedexHp.constructor.name).toBe('NumericIncrementTransform')
+    expect(pokedexHp.operand).toBe(1)
+  })
+}


### PR DESCRIPTION
@mesqueeb The `FieldValue` inside of `firebase/firestore` do not support `increment`, so I only added the test case for `firebase-admin/firestore`

- Run the test from v1.2.5, this should be failed ❌
  <img width="566" alt="截圖 2024-06-19 13 36 23" src="https://github.com/CyCraft/magnetar/assets/15190246/1d1767d4-85a6-4924-bb15-8f070d24636e">

- Run test after the bug fixed v1.2.7, this should be passed ✅
  <img width="597" alt="截圖 2024-06-19 13 52 19" src="https://github.com/CyCraft/magnetar/assets/15190246/313af0ae-a3f4-4fe2-98bc-f0df840eb860">
