### PR TITLE
feat: add local search ability

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   head: [['link', { rel: 'icon', type: 'image/svg+xml', href: '/icons/magnetar-icon.svg' }]],
   lastUpdated: true,
   themeConfig: {
+    search: {
+      provider: 'local',
+    },
     logo: {
       light: '/media/magnetar-logo-dark.svg',
       dark: '/media/magnetar-logo-white.svg',


### PR DESCRIPTION
Hello, 

I notice that this doc are not being add the searching capability for indexing keywords, and this functionality has been provided by `vitepress` which is the CMS this doc are using now, I just simply added an option to vitepress `config.ts` file to achieved this, not a plugin, just a local indexing ability.

Hope it can help other else to read this doc with a better experience.

The searching ability just like the image below: 

<img width="1441" height="909" alt="スクリーンショット 2025-10-07 10 22 19" src="https://github.com/user-attachments/assets/f053dc5c-dd61-4ca1-9460-8d2996ddd1f4" />

<img width="1425" height="64" alt="スクリーンショット 2025-10-07 10 29 56" src="https://github.com/user-attachments/assets/92083b16-e3cb-4f0f-a4c2-989b4478bc90" />
